### PR TITLE
Add Streamlit app for Ollama HTML auto-parsing

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,30 @@
+# Design
+
+## Architecture Overview
+- **Single-file application**: `index.html` contains markup, styles, and scripts.
+- **Event-driven UI**: toolbar actions and editor events update application state.
+- **State management**: simple JavaScript objects combined with browser `localStorage` for persistence.
+- **Preview rendering**: an `iframe` displays the current HTML in isolation.
+- **Ollama parser integration**: optional module sends HTML to a local Ollama server for analysis.
+- **Streamlit analyzer**: `ollama_app.py` fetches HTML from a URL and streams analysis results from Ollama.
+
+## Implementation Details
+- **Layout Management**: `applyLayout` switches between left-right, top-bottom, and preview-only modes.
+- **Preview Updates**: `updatePreview` injects editor content into the `iframe`.
+- **Line Numbers**: `updateLineNumbers` and `syncScroll` keep line numbers aligned with the editor.
+- **Resizing**: mouse/touch handlers on the gutter adjust panel sizes.
+- **Storage**: `saveCode` and `loadSavedCode` persist the editor state.
+- **Export**: `saveToFile` creates a downloadable HTML file using the document title.
+- **Parser Hook**: `analyzeHtml` (to be implemented) communicates with Ollama and displays results.
+- **External Libraries**: Feather Icons and Lodash are loaded via CDN.
+
+## File Structure
+```
+/
+├── ollama_app.py       # Streamlit entry point for Ollama analysis
+├── index.html           # main application
+└── docs/
+    ├── requirements.md  # project requirements
+    ├── design.md        # architecture and implementation details
+    └── parser.md        # Ollama parser specification
+```

--- a/docs/parser.md
+++ b/docs/parser.md
@@ -1,0 +1,30 @@
+# Ollama Parser Specification
+
+## Overview
+The parser feature uses [Ollama](https://ollama.ai/) to analyze HTML and return feedback such as structural suggestions or error messages. It is implemented in the Streamlit script `ollama_app.py`.
+
+## Endpoint
+- **Base URL**: `http://localhost:11434`
+- **API Path**: `/api/generate`
+- **Request**:
+  ```json
+  {
+    "model": "<model-name>",
+    "prompt": "<HTML content to analyze>"
+  }
+  ```
+- **Response**: JSON stream where each message chunk contains generated text. Collect all `response` fields to obtain the full parser output.
+
+## Usage Flow
+1. User triggers analysis (e.g., via toolbar button).
+2. `analyzeHtml(html)` sends a POST request to the Ollama endpoint with the editor contents.
+3. Display the aggregated parser response in a dedicated panel or modal.
+4. Handle network errors or empty responses with user-friendly messages.
+
+## Error Handling
+- If the Ollama server is unreachable, inform the user without disrupting editing.
+- Timeout requests after a reasonable period and allow retry.
+
+## Security Considerations
+- Only connect to a local Ollama instance; no remote data is transmitted.
+- Sanitize HTML before displaying parser output to avoid injection.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,23 @@
+# Requirements
+
+## Purpose
+Provide a single-page HTML preview application with real-time HTML editing, preview, and optional analysis via an Ollama-based parser.
+
+## Functional Requirements
+1. Real-time preview updates as the user edits HTML.
+2. Layout modes: left-right split, top-bottom split, and preview-only.
+3. Resizable panels controlled by a draggable gutter.
+4. Line numbers synchronized with the editor scroll position.
+5. Automatic saving of code to browser `localStorage`.
+6. Export of the current HTML as a downloadable file whose name reflects the document title.
+7. Integration with a local Ollama parser service for HTML analysis.
+   - Send the current HTML to the Ollama server over HTTP.
+   - Display parser feedback or suggestions within the UI.
+   - Handle connection or parsing errors gracefully.
+   - A companion Streamlit script `ollama_app.py` can also fetch external HTML and analyze it via the same service.
+
+## Non-Functional Requirements
+1. Distributed as a single `index.html` file with inline CSS and JavaScript.
+2. Runs offline in modern browsers without a build step.
+3. Uses vanilla web APIs and minimal external libraries (e.g. Feather Icons, Lodash).
+4. Code is structured and documented for maintainability.

--- a/ollama_app.py
+++ b/ollama_app.py
@@ -1,0 +1,79 @@
+import json
+import requests
+import streamlit as st
+from bs4 import BeautifulSoup
+
+OLLAMA_URL = "http://localhost:11434/api/generate"
+MODEL_NAME = "llama3"
+
+
+def fetch_html(url: str) -> str | None:
+    """Fetch raw HTML from a URL."""
+    try:
+        resp = requests.get(url, timeout=10)
+        resp.raise_for_status()
+        return resp.text
+    except Exception as e:
+        st.error(f"Failed to fetch HTML: {e}")
+        return None
+
+
+def parse_html(html: str) -> str:
+    """Return a prettified version of the HTML using BeautifulSoup."""
+    soup = BeautifulSoup(html, "html.parser")
+    return soup.prettify()
+
+
+def analyze_with_ollama(html: str) -> str | None:
+    """Send HTML to Ollama and return the generated analysis."""
+    try:
+        resp = requests.post(
+            OLLAMA_URL,
+            json={"model": MODEL_NAME, "prompt": html},
+            stream=True,
+            timeout=60,
+        )
+        resp.raise_for_status()
+        result = ""
+        for line in resp.iter_lines():
+            if not line:
+                continue
+            try:
+                chunk = json.loads(line.decode("utf-8"))
+            except json.JSONDecodeError:
+                continue
+            if "response" in chunk:
+                result += chunk["response"]
+        return result
+    except Exception as e:
+        st.error(f"Ollama request failed: {e}")
+        return None
+
+
+st.title("HTML Parser with Ollama")
+url = st.text_input("Enter URL")
+
+if "raw_html" not in st.session_state:
+    st.session_state.raw_html = ""
+if "parsed_html" not in st.session_state:
+    st.session_state.parsed_html = ""
+if "ollama_result" not in st.session_state:
+    st.session_state.ollama_result = ""
+
+if st.button("Fetch & Parse HTML") and url:
+    raw = fetch_html(url)
+    if raw:
+        st.session_state.raw_html = raw
+        st.session_state.parsed_html = parse_html(raw)
+        st.session_state.ollama_result = ""
+
+st.text_area("Parsed HTML", st.session_state.parsed_html, height=300)
+
+if st.button("Auto-parse with Ollama") and st.session_state.raw_html:
+    result = analyze_with_ollama(st.session_state.raw_html)
+    if result:
+        st.session_state.ollama_result = result
+
+if st.session_state.ollama_result:
+    st.subheader("Ollama Analysis")
+    st.text(st.session_state.ollama_result)


### PR DESCRIPTION
## Summary
- implement `ollama_app.py` Streamlit interface for fetching and parsing HTML from a URL
- document separation of `ollama_app.py` from the existing `index.html` app

## Testing
- `python -m py_compile ollama_app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb1e6d40832180ec65758bf05605