### PR TITLE
Enable automatic markdown list continuation

### DIFF
--- a/markdown_preview.html
+++ b/markdown_preview.html
@@ -18,6 +18,7 @@
       />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/codemirror.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/mode/markdown/markdown.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/addon/edit/continuelist.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
       <style>
       :root {
@@ -549,6 +550,7 @@ body.dragging,body.dragging *{cursor:col-resize!important}
           elements.htmlEditor = CodeMirror.fromTextArea(elements.htmlEditor, {
             lineNumbers: true,
             mode: "markdown",
+            extraKeys: { Enter: "newlineAndIndentContinueMarkdownList" }
           });
           loadSavedCode();
           let savedTheme;


### PR DESCRIPTION
## Summary
- load CodeMirror continuelist addon
- enable list continuation with Enter key in markdown editor

## Testing
- `python -m webbrowser markdown_preview.html`
- `xdg-open markdown_preview.html` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c4c847770483218e7271126c128868