### PR TITLE
Enable automatic list continuation in markdown preview

### DIFF
--- a/markdown_preview.html
+++ b/markdown_preview.html
@@ -18,6 +18,7 @@
       />
       <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/codemirror.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/mode/markdown/markdown.min.js"></script>
+      <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.7/addon/edit/continuelist.min.js"></script>
       <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/4.3.0/marked.min.js"></script>
       <style>
       :root {
@@ -549,6 +550,7 @@ body.dragging,body.dragging *{cursor:col-resize!important}
           elements.htmlEditor = CodeMirror.fromTextArea(elements.htmlEditor, {
             lineNumbers: true,
             mode: "markdown",
+            extraKeys: { Enter: "newlineAndIndentContinueMarkdownList" }
           });
           loadSavedCode();
           let savedTheme;


### PR DESCRIPTION
## Summary
- Load CodeMirror continuelist addon in markdown preview page
- Configure editor to automatically continue ordered lists when pressing Enter

## Testing
- ⚠️ `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68c4c83836d083219074a0e24ae120c7